### PR TITLE
Upgrade Hugo to v0.25.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ See the [Hugo Documentation](https://gohugo.io/) for more information.
 
 |  hugo-bin version | Hugo version |
 |:-----------------:|:------------:|
+|       ^0.12.0     |     v0.25.1  |
 |       ^0.11.0     |     v0.24.1  |
 |       ^0.10.0     |     v0.23    |
 |       ^0.9.0      |     v0.22.1  |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hugo-bin",
-  "version": "0.11.0",
-  "hugoVersion": "0.24.1",
+  "version": "0.12.0",
+  "hugoVersion": "0.25.1",
   "description": "Binary wrapper for Hugo",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
[Hugo 0.25.1](/gohugoio/hugo/releases/tag/v0.25.1) was released 20 days ago, this PR updates hugo to the latest version and bumps the package version to 0.12.0, inline with historic changes.