### PR TITLE
add support for new apple m1 processor - implemented as a fallback - …

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,7 @@ const extendedBin = new BinWrapper()
   .src(`${baseUrl}hugo_extended_${hugoVersion}_Linux-64bit.tar.gz`, 'linux', 'x64')
   .src(`${baseUrl}hugo_extended_${hugoVersion}_macOS-64bit.tar.gz`, 'darwin', 'x64')
   .src(`${baseUrl}hugo_extended_${hugoVersion}_macOS-ARM64.tar.gz`, 'darwin', 'arm64')
+  .src(`${baseUrl}hugo_extended_${hugoVersion}_macOS-ARM64.tar.gz`, 'darwin', undefined) // assume lib "bin-wrapper" was unable to identify arch due to new M1 chip
   .src(`${baseUrl}hugo_extended_${hugoVersion}_Windows-64bit.zip`, 'win32', 'x64')
   // Fall back to the normal version on unsupported platforms
   .src(`${baseUrl}hugo_${hugoVersion}_FreeBSD-64bit.tar.gz`, 'freebsd', 'x64')
@@ -37,6 +38,7 @@ const normalBin = new BinWrapper()
   .src(`${baseUrl}hugo_${hugoVersion}_Linux-ARM64.tar.gz`, 'linux', 'arm64')
   .src(`${baseUrl}hugo_${hugoVersion}_macOS-64bit.tar.gz`, 'darwin', 'x64')
   .src(`${baseUrl}hugo_${hugoVersion}_macOS-ARM64.tar.gz`, 'darwin', 'arm64')
+  .src(`${baseUrl}hugo_${hugoVersion}_macOS-ARM64.tar.gz`, 'darwin', undefined) // assume lib "bin-wrapper" was unable to identify arch due to new M1 chip   
   .src(`${baseUrl}hugo_${hugoVersion}_NetBSD-64bit.tar.gz`, 'netbsd', 'x64')
   .src(`${baseUrl}hugo_${hugoVersion}_OpenBSD-64bit.tar.gz`, 'openbsd', 'x64')
   .src(`${baseUrl}hugo_${hugoVersion}_Windows-32bit.zip`, 'win32', 'x86')


### PR DESCRIPTION
…source of bug: lib bin-wrapper is unable to identify arch for new apple m1