### PR TITLE
feat: Allowing to overwrite the Download Repository aka Download Mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ npm install hugo-bin --save-dev
 
 hugo-bin now supports the [Extended Hugo version](https://github.com/gohugoio/hugo/releases/tag/v0.43). See [Installation options](#installation-options) for more details.
 
+For usage within corporate networks or behind corporate proxies, the download repository can be overwritten, see [Installation options](#installation-options) for more details.
+
 ## Usage
 
 ### API
@@ -58,7 +60,7 @@ See the [Hugo Documentation](https://gohugo.io/) for more information.
 
 ## Installation options
 
-hugo-bin supports options to change the variation of Hugo binaries.
+hugo-bin supports options to change the variation of Hugo binaries and to overwrite the download repository.
 
 Each option can be configured in the `hugo-bin` section of your `package.json`:
 
@@ -67,7 +69,8 @@ Each option can be configured in the `hugo-bin` section of your `package.json`:
   "name": "your-package",
   "version": "0.0.1",
   "hugo-bin": {
-    "buildTags": "extended"
+    "buildTags": "extended",
+    "downloadRepo" : "https://some.example.com/artifactory/github-releases"
   }
 }
 ```
@@ -76,12 +79,14 @@ Also as local or global [.npmrc](https://docs.npmjs.com/files/npmrc) configurati
 
 ```ini
 hugo_bin_build_tags = "extended"
+hugo_bin_download_repo = "https://some.example.com/artifactory/github-releases"
 ```
 
 Also as an environment variable:
 
 ```sh
 export HUGO_BIN_BUILD_TAGS="extended"
+export HUGO_BIN_DOWNLOAD_REPO="https://some.example.com/artifactory/github-releases"
 ```
 
 **Note that you have to run `npm install hugo-bin` to re-install hugo-bin itself, if you change any of these options.**
@@ -95,6 +100,12 @@ Default: `""`
 Set it to `extended` to download the [extended version](https://github.com/gohugoio/hugo/releases/tag/v0.43) binary.
 
 If this is set to `extended` but it's not available for the user's platform, then the normal version will be downloaded instead.
+
+#### downloadRepo
+
+Default: `"https://github.com"`
+
+Set it to your corporate proxy url to download the hugo binary from a different download repository.
 
 ## Supported versions
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,50 +7,52 @@ import { packageConfigSync } from 'pkg-conf';
 
 const { hugoVersion } = JSON.parse(fs.readFileSync(new URL('../package.json', import.meta.url)));
 
-const baseUrl = `https://github.com/gohugoio/hugo/releases/download/v${hugoVersion}/`;
 const destDir = path.join(fileURLToPath(new URL('../vendor', import.meta.url)));
 const binName = process.platform === 'win32' ? 'hugo.exe' : 'hugo';
 
-const extendedBin = new BinWrapper()
-  .src(`${baseUrl}hugo_extended_${hugoVersion}_Linux-64bit.tar.gz`, 'linux', 'x64')
-  .src(`${baseUrl}hugo_extended_${hugoVersion}_macOS-64bit.tar.gz`, 'darwin', 'x64')
-  .src(`${baseUrl}hugo_extended_${hugoVersion}_macOS-ARM64.tar.gz`, 'darwin', 'arm64')
-  .src(`${baseUrl}hugo_extended_${hugoVersion}_Windows-64bit.zip`, 'win32', 'x64')
+const extendedBin = (baseDownloadUrl) => new BinWrapper()
+  .src(`${baseDownloadUrl}hugo_extended_${hugoVersion}_Linux-64bit.tar.gz`, 'linux', 'x64')
+  .src(`${baseDownloadUrl}hugo_extended_${hugoVersion}_macOS-64bit.tar.gz`, 'darwin', 'x64')
+  .src(`${baseDownloadUrl}hugo_extended_${hugoVersion}_macOS-ARM64.tar.gz`, 'darwin', 'arm64')
+  .src(`${baseDownloadUrl}hugo_extended_${hugoVersion}_Windows-64bit.zip`, 'win32', 'x64')
   // Fall back to the normal version on unsupported platforms
-  .src(`${baseUrl}hugo_${hugoVersion}_FreeBSD-64bit.tar.gz`, 'freebsd', 'x64')
-  .src(`${baseUrl}hugo_${hugoVersion}_Linux-32bit.tar.gz`, 'linux', 'x86')
-  .src(`${baseUrl}hugo_${hugoVersion}_Linux-ARM.tar.gz`, 'linux', 'arm')
-  .src(`${baseUrl}hugo_${hugoVersion}_Linux-ARM64.tar.gz`, 'linux', 'arm64')
-  .src(`${baseUrl}hugo_${hugoVersion}_NetBSD-64bit.tar.gz`, 'netbsd', 'x64')
-  .src(`${baseUrl}hugo_${hugoVersion}_OpenBSD-64bit.tar.gz`, 'openbsd', 'x64')
-  .src(`${baseUrl}hugo_${hugoVersion}_Windows-32bit.zip`, 'win32', 'x86')
-  .src(`${baseUrl}hugo_${hugoVersion}_Windows-ARM.zip`, 'win32', 'arm')
-  .src(`${baseUrl}hugo_${hugoVersion}_Windows-ARM64.zip`, 'win32', 'arm64')
+  .src(`${baseDownloadUrl}hugo_${hugoVersion}_FreeBSD-64bit.tar.gz`, 'freebsd', 'x64')
+  .src(`${baseDownloadUrl}hugo_${hugoVersion}_Linux-32bit.tar.gz`, 'linux', 'x86')
+  .src(`${baseDownloadUrl}hugo_${hugoVersion}_Linux-ARM.tar.gz`, 'linux', 'arm')
+  .src(`${baseDownloadUrl}hugo_${hugoVersion}_Linux-ARM64.tar.gz`, 'linux', 'arm64')
+  .src(`${baseDownloadUrl}hugo_${hugoVersion}_NetBSD-64bit.tar.gz`, 'netbsd', 'x64')
+  .src(`${baseDownloadUrl}hugo_${hugoVersion}_OpenBSD-64bit.tar.gz`, 'openbsd', 'x64')
+  .src(`${baseDownloadUrl}hugo_${hugoVersion}_Windows-32bit.zip`, 'win32', 'x86')
+  .src(`${baseDownloadUrl}hugo_${hugoVersion}_Windows-ARM.zip`, 'win32', 'arm')
+  .src(`${baseDownloadUrl}hugo_${hugoVersion}_Windows-ARM64.zip`, 'win32', 'arm64')
   .dest(destDir)
   .use(binName);
 
-const normalBin = new BinWrapper()
-  .src(`${baseUrl}hugo_${hugoVersion}_FreeBSD-64bit.tar.gz`, 'freebsd', 'x64')
-  .src(`${baseUrl}hugo_${hugoVersion}_Linux-32bit.tar.gz`, 'linux', 'x86')
-  .src(`${baseUrl}hugo_${hugoVersion}_Linux-64bit.tar.gz`, 'linux', 'x64')
-  .src(`${baseUrl}hugo_${hugoVersion}_Linux-ARM.tar.gz`, 'linux', 'arm')
-  .src(`${baseUrl}hugo_${hugoVersion}_Linux-ARM64.tar.gz`, 'linux', 'arm64')
-  .src(`${baseUrl}hugo_${hugoVersion}_macOS-64bit.tar.gz`, 'darwin', 'x64')
-  .src(`${baseUrl}hugo_${hugoVersion}_macOS-ARM64.tar.gz`, 'darwin', 'arm64')
-  .src(`${baseUrl}hugo_${hugoVersion}_NetBSD-64bit.tar.gz`, 'netbsd', 'x64')
-  .src(`${baseUrl}hugo_${hugoVersion}_OpenBSD-64bit.tar.gz`, 'openbsd', 'x64')
-  .src(`${baseUrl}hugo_${hugoVersion}_Windows-32bit.zip`, 'win32', 'x86')
-  .src(`${baseUrl}hugo_${hugoVersion}_Windows-64bit.zip`, 'win32', 'x64')
-  .src(`${baseUrl}hugo_${hugoVersion}_Windows-ARM.zip`, 'win32', 'arm')
-  .src(`${baseUrl}hugo_${hugoVersion}_Windows-ARM64.zip`, 'win32', 'arm64')
+const normalBin = (baseDownloadUrl) => new BinWrapper()
+  .src(`${baseDownloadUrl}hugo_${hugoVersion}_FreeBSD-64bit.tar.gz`, 'freebsd', 'x64')
+  .src(`${baseDownloadUrl}hugo_${hugoVersion}_Linux-32bit.tar.gz`, 'linux', 'x86')
+  .src(`${baseDownloadUrl}hugo_${hugoVersion}_Linux-64bit.tar.gz`, 'linux', 'x64')
+  .src(`${baseDownloadUrl}hugo_${hugoVersion}_Linux-ARM.tar.gz`, 'linux', 'arm')
+  .src(`${baseDownloadUrl}hugo_${hugoVersion}_Linux-ARM64.tar.gz`, 'linux', 'arm64')
+  .src(`${baseDownloadUrl}hugo_${hugoVersion}_macOS-64bit.tar.gz`, 'darwin', 'x64')
+  .src(`${baseDownloadUrl}hugo_${hugoVersion}_macOS-ARM64.tar.gz`, 'darwin', 'arm64')
+  .src(`${baseDownloadUrl}hugo_${hugoVersion}_NetBSD-64bit.tar.gz`, 'netbsd', 'x64')
+  .src(`${baseDownloadUrl}hugo_${hugoVersion}_OpenBSD-64bit.tar.gz`, 'openbsd', 'x64')
+  .src(`${baseDownloadUrl}hugo_${hugoVersion}_Windows-32bit.zip`, 'win32', 'x86')
+  .src(`${baseDownloadUrl}hugo_${hugoVersion}_Windows-64bit.zip`, 'win32', 'x64')
+  .src(`${baseDownloadUrl}hugo_${hugoVersion}_Windows-ARM.zip`, 'win32', 'arm')
+  .src(`${baseDownloadUrl}hugo_${hugoVersion}_Windows-ARM64.zip`, 'win32', 'arm64')
   .dest(destDir)
   .use(binName);
 
 function main(projectRoot) {
   const config = packageConfigSync('hugo-bin', { cwd: projectRoot });
   const extended = (process.env.HUGO_BIN_BUILD_TAGS || process.env.npm_config_hugo_bin_build_tags || config.buildTags) === 'extended';
+  const downloadRepo = (process.env.HUGO_BIN_DOWNLOAD_REPO || process.env.npm_config_hugo_bin_download_repo || config.downloadRepo || 'https://github.com');
 
-  return extended ? extendedBin : normalBin;
+  const baseDownloadUrl = `${downloadRepo}/gohugoio/hugo/releases/download/v${hugoVersion}/`;
+
+  return extended ? extendedBin(baseDownloadUrl) : normalBin(baseDownloadUrl);
 }
 
 export default main;

--- a/test/index.js
+++ b/test/index.js
@@ -1,9 +1,9 @@
+import { strict as assert } from 'node:assert';
 import process from 'node:process';
 import binCheck from 'bin-check';
 import { test } from 'uvu';
 import hugoBin from '../index.js';
 import hugoLib from '../lib/index.js';
-import { strict as assert } from 'node:assert';
 
 test('should return path to binary and work', () => {
   return binCheck(hugoBin, ['version']).then(works => {

--- a/test/index.js
+++ b/test/index.js
@@ -3,7 +3,7 @@ import binCheck from 'bin-check';
 import { test } from 'uvu';
 import hugoBin from '../index.js';
 import hugoLib from '../lib/index.js';
-import assert from 'node:assert';
+import { strict as assert } from 'node:assert';
 
 test('should return path to binary and work', () => {
   return binCheck(hugoBin, ['version']).then(works => {

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 import { strict as assert } from 'node:assert';
 import process from 'node:process';
 import binCheck from 'bin-check';
-import { test } from 'uvu';
+import { test, suite } from 'uvu';
 import hugoBin from '../index.js';
 import hugoLib from '../lib/index.js';
 
@@ -11,36 +11,76 @@ test('should return path to binary and work', () => {
   });
 });
 
-test('should return overwritten repository url', () => {
-  // Verify for Default Repository and Not Extended
-  process.env.npm_config_hugo_bin_build_tags = '';
-  const defaultRepoSources = hugoLib(process.cwd())._src.map(v => v.url);
-  defaultRepoSources.forEach((sourceUrl) => {
+test.run();
+
+/**
+ * Verify Custom/Enterprise Repository overwrite.
+ */
+
+const hugoLibCustomRepoTestSuite = suite('hugo-bin overwrite download repository');
+
+hugoLibCustomRepoTestSuite.before.each(() => {
+  // Ensure that the environment is cleaned before next test run.
+  delete process.env.npm_config_hugo_bin_build_tags;
+  delete process.env.npm_config_hugo_bin_download_repo;
+});
+
+hugoLibCustomRepoTestSuite('verify test env', () => {
+  assert.equal(process.env.npm_config_hugo_bin_build_tags, undefined);
+  assert.equal(process.env.npm_config_hugo_bin_download_repo, undefined);
+})
+
+// Default Repository - Test Cases
+
+hugoLibCustomRepoTestSuite('should return default repository url - Repository: default - Extended: undefined', () => {
+  const repoSources = hugoLib(process.cwd())._src.map((v) => v.url);
+  repoSources.forEach((sourceUrl) => {
     assert.ok(sourceUrl.startsWith('https://github.com/'));
-  });
-
-  // Verify for Default Repository and Extended
-  process.env.npm_config_hugo_bin_build_tags = 'extended';
-  const defaultRepoSourcesExtended = hugoLib(process.cwd())._src.map(v => v.url);
-  defaultRepoSourcesExtended.forEach((sourceUrl) => {
-    assert.ok(sourceUrl.startsWith('https://github.com/'));
-  });
-
-  // Verify for Custom Repository and Not Extended
-  process.env.npm_config_hugo_bin_build_tags = '';
-  process.env.npm_config_hugo_bin_download_repo = 'https://some.example.com';
-  const customRepoSources = hugoLib(process.cwd())._src.map(v => v.url);
-  customRepoSources.forEach((sourceUrl) => {
-    assert.ok(sourceUrl.startsWith('https://some.example.com/'));
-  });
-
-  // Verify for Custom Repository and Extended
-  process.env.npm_config_hugo_bin_build_tags = 'extended';
-  process.env.npm_config_hugo_bin_download_repo = 'https://some.example.com';
-  const customRepoSourcesExtended = hugoLib(process.cwd())._src.map(v => v.url);
-  customRepoSourcesExtended.forEach((sourceUrl) => {
-    assert.ok(sourceUrl.startsWith('https://some.example.com/'));
   });
 });
 
-test.run();
+hugoLibCustomRepoTestSuite('should return default repository url - Repository: default - Extended: empty', () => {
+  process.env.npm_config_hugo_bin_build_tags = '';
+  const repoSources = hugoLib(process.cwd())._src.map((v) => v.url);
+  repoSources.forEach((sourceUrl) => {
+    assert.ok(sourceUrl.startsWith('https://github.com/'));
+  });
+});
+
+hugoLibCustomRepoTestSuite('should return default repository url - Repository: default - Extended: extended', () => {
+  process.env.npm_config_hugo_bin_build_tags = 'extended';
+  const repoSources = hugoLib(process.cwd())._src.map((v) => v.url);
+  repoSources.forEach((sourceUrl) => {
+    assert.ok(sourceUrl.startsWith('https://github.com/'));
+  });
+});
+
+// Custom/Enterprise Repository Test Cases
+
+hugoLibCustomRepoTestSuite('should return custom repository url - Repository: custom - Extended: undefined', () => {
+  process.env.npm_config_hugo_bin_download_repo = 'https://some1.example.com';
+  const repoSources = hugoLib(process.cwd())._src.map((v) => v.url);
+  repoSources.forEach((sourceUrl) => {
+    assert.ok(sourceUrl.startsWith('https://some1.example.com/'));
+  });
+});
+
+hugoLibCustomRepoTestSuite('should return custom repository url - Repository: custom - Extended: empty', () => {
+  process.env.npm_config_hugo_bin_build_tags = '';
+  process.env.npm_config_hugo_bin_download_repo = 'https://some2.example.com';
+  const repoSources = hugoLib(process.cwd())._src.map((v) => v.url);
+  repoSources.forEach((sourceUrl) => {
+    assert.ok(sourceUrl.startsWith('https://some2.example.com/'));
+  });
+});
+
+hugoLibCustomRepoTestSuite('should return custom repository url - Repository: custom - Extended: extended', () => {
+  process.env.npm_config_hugo_bin_build_tags = 'extended';
+  process.env.npm_config_hugo_bin_download_repo = 'https://some3.example.com';
+  const repoSources = hugoLib(process.cwd())._src.map((v) => v.url);
+  repoSources.forEach((sourceUrl) => {
+    assert.ok(sourceUrl.startsWith('https://some3.example.com/'));
+  });
+});
+
+hugoLibCustomRepoTestSuite.run();

--- a/test/index.js
+++ b/test/index.js
@@ -16,7 +16,7 @@ test('should return overwritten repository url', () => {
   process.env.npm_config_hugo_bin_build_tags = '';
   const defaultRepoSources = hugoLib(process.cwd())._src.map((v) => v.url);
   defaultRepoSources.forEach((sourceUrl) => {
-    assert.equal(sourceUrl.startsWith('https://github.com/'), true);
+    assert.ok(sourceUrl.startsWith('https://github.com/'));
   });
 
   // Verify for Default Repository and Extended
@@ -25,7 +25,7 @@ test('should return overwritten repository url', () => {
     (v) => v.url
   );
   defaultRepoSourcesExtended.forEach((sourceUrl) => {
-    assert.equal(sourceUrl.startsWith('https://github.com/'), true);
+    assert.ok(sourceUrl.startsWith('https://github.com/'));
   });
 
   // Verify for Custom Repository and Not Extended
@@ -33,7 +33,7 @@ test('should return overwritten repository url', () => {
   process.env.npm_config_hugo_bin_download_repo = 'https://some.example.com';
   const customRepoSources = hugoLib(process.cwd())._src.map((v) => v.url);
   customRepoSources.forEach((sourceUrl) => {
-    assert.equal(sourceUrl.startsWith('https://some.example.com/'), true);
+    assert.ok(sourceUrl.startsWith('https://some.example.com/'));
   });
 
   // Verify for Custom Repository and Extended
@@ -43,7 +43,7 @@ test('should return overwritten repository url', () => {
     (v) => v.url
   );
   customRepoSourcesExtended.forEach((sourceUrl) => {
-    assert.equal(sourceUrl.startsWith('https://some.example.com/'), true);
+    assert.ok(sourceUrl.startsWith('https://some.example.com/'));
   });
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,49 +1,49 @@
-import process from "node:process";
-import binCheck from "bin-check";
-import { test } from "uvu";
-import hugoBin from "../index.js";
-import hugoLib from "../lib/index.js";
-import * as assert from "uvu/assert";
+import process from 'node:process';
+import binCheck from 'bin-check';
+import { test } from 'uvu';
+import hugoBin from '../index.js';
+import hugoLib from '../lib/index.js';
+import assert from 'node:assert';
 
-test("should return path to binary and work", () => {
-  return binCheck(hugoBin, ["version"]).then((works) => {
+test('should return path to binary and work', () => {
+  return binCheck(hugoBin, ['version']).then(works => {
     assert.ok(works);
   });
 });
 
-test("should return overwritten repository url", () => {
+test('should return overwritten repository url', () => {
   // Verify for Default Repository and Not Extended
-  process.env.npm_config_hugo_bin_build_tags = "";
+  process.env.npm_config_hugo_bin_build_tags = '';
   const defaultRepoSources = hugoLib(process.cwd())._src.map((v) => v.url);
   defaultRepoSources.forEach((sourceUrl) => {
-    assert.is(sourceUrl.startsWith("https://github.com/"), true);
+    assert.equal(sourceUrl.startsWith('https://github.com/'), true);
   });
 
   // Verify for Default Repository and Extended
-  process.env.npm_config_hugo_bin_build_tags = "extended";
+  process.env.npm_config_hugo_bin_build_tags = 'extended';
   const defaultRepoSourcesExtended = hugoLib(process.cwd())._src.map(
     (v) => v.url
   );
   defaultRepoSourcesExtended.forEach((sourceUrl) => {
-    assert.is(sourceUrl.startsWith("https://github.com/"), true);
+    assert.equal(sourceUrl.startsWith('https://github.com/'), true);
   });
 
   // Verify for Custom Repository and Not Extended
-  process.env.npm_config_hugo_bin_build_tags = "";
-  process.env.npm_config_hugo_bin_download_repo = "https://some.example.com";
+  process.env.npm_config_hugo_bin_build_tags = '';
+  process.env.npm_config_hugo_bin_download_repo = 'https://some.example.com';
   const customRepoSources = hugoLib(process.cwd())._src.map((v) => v.url);
   customRepoSources.forEach((sourceUrl) => {
-    assert.is(sourceUrl.startsWith("https://some.example.com/"), true);
+    assert.equal(sourceUrl.startsWith('https://some.example.com/'), true);
   });
 
   // Verify for Custom Repository and Extended
-  process.env.npm_config_hugo_bin_build_tags = "extended";
-  process.env.npm_config_hugo_bin_download_repo = "https://some.example.com";
+  process.env.npm_config_hugo_bin_build_tags = 'extended';
+  process.env.npm_config_hugo_bin_download_repo = 'https://some.example.com';
   const customRepoSourcesExtended = hugoLib(process.cwd())._src.map(
     (v) => v.url
   );
   customRepoSourcesExtended.forEach((sourceUrl) => {
-    assert.is(sourceUrl.startsWith("https://some.example.com/"), true);
+    assert.equal(sourceUrl.startsWith('https://some.example.com/'), true);
   });
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -14,16 +14,14 @@ test('should return path to binary and work', () => {
 test('should return overwritten repository url', () => {
   // Verify for Default Repository and Not Extended
   process.env.npm_config_hugo_bin_build_tags = '';
-  const defaultRepoSources = hugoLib(process.cwd())._src.map((v) => v.url);
+  const defaultRepoSources = hugoLib(process.cwd())._src.map(v => v.url);
   defaultRepoSources.forEach((sourceUrl) => {
     assert.ok(sourceUrl.startsWith('https://github.com/'));
   });
 
   // Verify for Default Repository and Extended
   process.env.npm_config_hugo_bin_build_tags = 'extended';
-  const defaultRepoSourcesExtended = hugoLib(process.cwd())._src.map(
-    (v) => v.url
-  );
+  const defaultRepoSourcesExtended = hugoLib(process.cwd())._src.map(v => v.url);
   defaultRepoSourcesExtended.forEach((sourceUrl) => {
     assert.ok(sourceUrl.startsWith('https://github.com/'));
   });
@@ -31,7 +29,7 @@ test('should return overwritten repository url', () => {
   // Verify for Custom Repository and Not Extended
   process.env.npm_config_hugo_bin_build_tags = '';
   process.env.npm_config_hugo_bin_download_repo = 'https://some.example.com';
-  const customRepoSources = hugoLib(process.cwd())._src.map((v) => v.url);
+  const customRepoSources = hugoLib(process.cwd())._src.map(v => v.url);
   customRepoSources.forEach((sourceUrl) => {
     assert.ok(sourceUrl.startsWith('https://some.example.com/'));
   });
@@ -39,9 +37,7 @@ test('should return overwritten repository url', () => {
   // Verify for Custom Repository and Extended
   process.env.npm_config_hugo_bin_build_tags = 'extended';
   process.env.npm_config_hugo_bin_download_repo = 'https://some.example.com';
-  const customRepoSourcesExtended = hugoLib(process.cwd())._src.map(
-    (v) => v.url
-  );
+  const customRepoSourcesExtended = hugoLib(process.cwd())._src.map(v => v.url);
   customRepoSourcesExtended.forEach((sourceUrl) => {
     assert.ok(sourceUrl.startsWith('https://some.example.com/'));
   });

--- a/test/index.js
+++ b/test/index.js
@@ -1,11 +1,49 @@
-import { strict as assert } from 'node:assert';
-import binCheck from 'bin-check';
-import { test } from 'uvu';
-import hugoBin from '../index.js';
+import process from "node:process";
+import binCheck from "bin-check";
+import { test } from "uvu";
+import hugoBin from "../index.js";
+import hugoLib from "../lib/index.js";
+import * as assert from "uvu/assert";
 
-test('should return path to binary and work', () => {
-  return binCheck(hugoBin, ['version']).then(works => {
+test("should return path to binary and work", () => {
+  return binCheck(hugoBin, ["version"]).then((works) => {
     assert.ok(works);
+  });
+});
+
+test("should return overwritten repository url", () => {
+  // Verify for Default Repository and Not Extended
+  process.env.npm_config_hugo_bin_build_tags = "";
+  const defaultRepoSources = hugoLib(process.cwd())._src.map((v) => v.url);
+  defaultRepoSources.forEach((sourceUrl) => {
+    assert.is(sourceUrl.startsWith("https://github.com/"), true);
+  });
+
+  // Verify for Default Repository and Extended
+  process.env.npm_config_hugo_bin_build_tags = "extended";
+  const defaultRepoSourcesExtended = hugoLib(process.cwd())._src.map(
+    (v) => v.url
+  );
+  defaultRepoSourcesExtended.forEach((sourceUrl) => {
+    assert.is(sourceUrl.startsWith("https://github.com/"), true);
+  });
+
+  // Verify for Custom Repository and Not Extended
+  process.env.npm_config_hugo_bin_build_tags = "";
+  process.env.npm_config_hugo_bin_download_repo = "https://some.example.com";
+  const customRepoSources = hugoLib(process.cwd())._src.map((v) => v.url);
+  customRepoSources.forEach((sourceUrl) => {
+    assert.is(sourceUrl.startsWith("https://some.example.com/"), true);
+  });
+
+  // Verify for Custom Repository and Extended
+  process.env.npm_config_hugo_bin_build_tags = "extended";
+  process.env.npm_config_hugo_bin_download_repo = "https://some.example.com";
+  const customRepoSourcesExtended = hugoLib(process.cwd())._src.map(
+    (v) => v.url
+  );
+  customRepoSourcesExtended.forEach((sourceUrl) => {
+    assert.is(sourceUrl.startsWith("https://some.example.com/"), true);
   });
 });
 


### PR DESCRIPTION
When using hugo-bin within corporate environments it is often required to use a corporate proxy repository like Artifactory to download your dependencies, because access to internet is restricted.

I extended your implementation for switching to the extended version and now it is allowing to set a downloadRepo parameter which will replace the default https://github.com

fixes #112